### PR TITLE
Fix default CRA test to match actual Portfolio text

### DIFF
--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders portfolio link', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
+  const linkElement = screen.getByText(/portfolio/i);
   expect(linkElement).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- update App.test to look for 'Portfolio' text instead of non-existent 'learn react'

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68bfccf9c908832da944d9b0147b32b4