### PR TITLE
Handle missing company URLs in experience section

### DIFF
--- a/src/components/sections/Experience/ExperienceSection.js
+++ b/src/components/sections/Experience/ExperienceSection.js
@@ -59,15 +59,21 @@ const ExperienceSection = () => {
                 <h3 className="experience__position">
                   {experiences[displayedTab].position}
                   <span className="experience__at"> @ </span>
-                  <a 
-                    href={experiences[displayedTab].website}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="experience__company"
-                  >
-                    {experiences[displayedTab].company}
-                    <ExternalLink size={16} className="experience__external-icon" />
-                  </a>
+                  {experiences[displayedTab].website ? (
+                    <a
+                      href={experiences[displayedTab].website}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="experience__company"
+                    >
+                      {experiences[displayedTab].company}
+                      <ExternalLink size={16} className="experience__external-icon" />
+                    </a>
+                  ) : (
+                    <span className="experience__company">
+                      {experiences[displayedTab].company}
+                    </span>
+                  )}
                 </h3>
                 
                 <div className="experience__meta">


### PR DESCRIPTION
## Summary
- Render company name without link when no website is provided
- Only show external link icon when a URL exists

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68bfced6d3cc832da7472115598cdfac